### PR TITLE
Fix working directory in github workflow

### DIFF
--- a/.github/workflows/build-deploy-gh-pages.yml
+++ b/.github/workflows/build-deploy-gh-pages.yml
@@ -19,12 +19,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install and Build
+        working-directory: ./jinzai-dentaku
         run:  |
           npm ci
           npm run build
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.5
+        working-directory: ./jinzai-dentaku
         with:
           branch: gh-pages
           folder: build


### PR DESCRIPTION
The react-app is not at the top level directory which caused an error. This change adds a working directory tag to instruct the action to complete in the correct folder.